### PR TITLE
expected error messages in a format of regex

### DIFF
--- a/examples/python/duckdb-python.py
+++ b/examples/python/duckdb-python.py
@@ -100,7 +100,7 @@ print(rel.limit(2))
 print(rel.limit(2, offset=1))
 
 # of course these things can be chained
-print(rel.filter('i > 1').project('i + 1').order('j').limit(2))
+print(rel.filter('i > 1').project('i + 1, j').order('j').limit(2))
 
 # aggregate the relation
 print(rel.aggregate("sum(i)"))
@@ -136,7 +136,7 @@ print(duckdb.aggregate(test_df, "sum(i)"))
 print(duckdb.distinct(test_df))
 
 # when chaining only the first call needs to include the data frame parameter
-print(duckdb.filter(test_df, 'i > 1').project('i + 1').order('j').limit(2))
+print(duckdb.filter(test_df, 'i > 1').project('i + 1, j').order('j').limit(2))
 
 # turn the relation into something else again
 
@@ -181,5 +181,5 @@ print(res.fetchdf())
 print(res.df())
 
 # this also works directly on data frames
-res = duckdb.query(test_df, 'my_name_for_test_df', 'SELECT * FROM my_name_for_test_df')
+res = duckdb.query_df(test_df, 'my_name_for_test_df', 'SELECT * FROM my_name_for_test_df')
 print(res.df())

--- a/src/common/error_data.cpp
+++ b/src/common/error_data.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/common/error_data.hpp"
-#include "duckdb/common/exception.hpp"
 
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/common/types.hpp"
@@ -50,7 +50,10 @@ ErrorData::ErrorData(const string &message) : initialized(true), type(ExceptionT
 
 const string &ErrorData::Message() {
 	if (final_message.empty()) {
-		final_message = Exception::ExceptionTypeToString(type) + " Error: " + raw_message;
+		if (type != ExceptionType::UNKNOWN_TYPE) {
+			final_message = Exception::ExceptionTypeToString(type) + " ";
+		}
+		final_message += "Error: " + raw_message;
 		if (type == ExceptionType::INTERNAL) {
 			final_message += "\nThis error signals an assertion failure within DuckDB. This usually occurs due to "
 			                 "unexpected conditions or errors in the program's logic.\nFor more information, see "

--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -14,6 +14,9 @@
 
 namespace duckdb {
 
+MultiFileReaderGlobalState::~MultiFileReaderGlobalState() {
+}
+
 MultiFileReader::~MultiFileReader() {
 }
 

--- a/src/core_functions/aggregate/holistic/quantile.cpp
+++ b/src/core_functions/aggregate/holistic/quantile.cpp
@@ -1509,12 +1509,20 @@ unique_ptr<FunctionData> BindQuantile(ClientContext &context, AggregateFunction 
 		throw BinderException("QUANTILE argument must not be NULL");
 	}
 	vector<Value> quantiles;
-	if (quantile_val.type().id() != LogicalTypeId::LIST) {
-		quantiles.push_back(CheckQuantile(quantile_val));
-	} else {
+	switch (quantile_val.type().id()) {
+	case LogicalTypeId::LIST:
 		for (const auto &element_val : ListValue::GetChildren(quantile_val)) {
 			quantiles.push_back(CheckQuantile(element_val));
 		}
+		break;
+	case LogicalTypeId::ARRAY:
+		for (const auto &element_val : ArrayValue::GetChildren(quantile_val)) {
+			quantiles.push_back(CheckQuantile(element_val));
+		}
+		break;
+	default:
+		quantiles.push_back(CheckQuantile(quantile_val));
+		break;
 	}
 
 	Function::EraseArgument(function, arguments, arguments.size() - 1);

--- a/src/execution/operator/persistent/physical_copy_database.cpp
+++ b/src/execution/operator/persistent/physical_copy_database.cpp
@@ -49,8 +49,10 @@ SourceResultType PhysicalCopyDatabase::GetData(ExecutionContext &context, DataCh
 			catalog.CreateTable(context.client, *bound_info);
 			break;
 		}
+		case CatalogType::INDEX_ENTRY:
 		default:
-			throw InternalException("Entry type not supported in PhysicalCopyDatabase");
+			throw NotImplementedException("Entry type %s not supported in PhysicalCopyDatabase",
+			                              CatalogTypeToString(create_info->type));
 		}
 	}
 	return SourceResultType::FINISHED;

--- a/src/function/table/system/duckdb_extensions.cpp
+++ b/src/function/table/system/duckdb_extensions.cpp
@@ -125,7 +125,7 @@ unique_ptr<GlobalTableFunctionState> DuckDBExtensionsInit(ClientContext &context
 		if (entry == installed_extensions.end()) {
 			installed_extensions[info.name] = std::move(info);
 		} else {
-			if (!entry->second.loaded) {
+			if (entry->second.install_mode != ExtensionInstallMode::STATICALLY_LINKED) {
 				entry->second.file_path = info.file_path;
 				entry->second.install_mode = info.install_mode;
 				entry->second.installed_from = info.installed_from;
@@ -144,13 +144,12 @@ unique_ptr<GlobalTableFunctionState> DuckDBExtensionsInit(ClientContext &context
 		auto &ext_info = e.second;
 		auto entry = installed_extensions.find(ext_name);
 		if (entry == installed_extensions.end() || !entry->second.installed) {
-			ExtensionInformation info;
+			ExtensionInformation &info = installed_extensions[ext_name];
 			info.name = ext_name;
 			info.loaded = true;
 			info.extension_version = ext_info.version;
 			info.installed = ext_info.mode == ExtensionInstallMode::STATICALLY_LINKED;
 			info.install_mode = ext_info.mode;
-			installed_extensions[ext_name] = std::move(info);
 		} else {
 			entry->second.loaded = true;
 			entry->second.extension_version = ext_info.version;

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -35,6 +35,13 @@
 #endif
 #endif
 
+//! In the future, we are planning to move extension functions to a separate header. For now you can set the define
+//! below to remove the functions that are planned to be moved out of this header.
+// #define DUCKDB_NO_EXTENSION_FUNCTIONS
+
+//! Set the define below to remove all functions that are deprecated or planned to be deprecated
+// #define DUCKDB_API_NO_DEPRECATED
+
 //! API versions
 //! If no explicit API version is defined, the latest API version is used.
 //! Note that using older API versions (i.e. not using DUCKDB_API_LATEST) is deprecated.
@@ -433,6 +440,7 @@ typedef struct _duckdb_value {
 // Table function types
 //===--------------------------------------------------------------------===//
 
+#ifndef DUCKDB_NO_EXTENSION_FUNCTIONS
 //! A table function. Must be destroyed with `duckdb_destroy_table_function`.
 typedef void *duckdb_table_function;
 
@@ -463,6 +471,7 @@ typedef void *duckdb_replacement_scan_info;
 
 //! A replacement scan function that can be added to a database.
 typedef void (*duckdb_replacement_callback_t)(duckdb_replacement_scan_info info, const char *table_name, void *data);
+#endif
 
 //===--------------------------------------------------------------------===//
 // Arrow-related types
@@ -709,13 +718,17 @@ Returns the number of columns present in a the result object.
 */
 DUCKDB_API idx_t duckdb_column_count(duckdb_result *result);
 
+#ifndef DUCKDB_API_NO_DEPRECATED
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Returns the number of rows present in the result object.
 
 * result: The result object.
 * returns: The number of rows present in the result object.
 */
 DUCKDB_API idx_t duckdb_row_count(duckdb_result *result);
+#endif
 
 /*!
 Returns the number of rows changed by the query stored in the result. This is relevant only for INSERT/UPDATE/DELETE
@@ -726,6 +739,7 @@ queries. For other queries the rows_changed will be 0.
 */
 DUCKDB_API idx_t duckdb_rows_changed(duckdb_result *result);
 
+#ifndef DUCKDB_API_NO_DEPRECATED
 /*!
 **DEPRECATED**: Prefer using `duckdb_result_get_chunk` instead.
 
@@ -769,6 +783,7 @@ if (nullmask[row]) {
 * returns: The nullmask of the specified column.
 */
 DUCKDB_API bool *duckdb_nullmask_data(duckdb_result *result, idx_t col);
+#endif
 
 /*!
 Returns the error message contained within the result. The error is only set if `duckdb_query` returns `DuckDBError`.
@@ -783,8 +798,10 @@ DUCKDB_API const char *duckdb_result_error(duckdb_result *result);
 //===--------------------------------------------------------------------===//
 // Result Functions
 //===--------------------------------------------------------------------===//
-
+#ifndef DUCKDB_API_NO_DEPRECATED
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Fetches a data chunk from the duckdb_result. This function should be called repeatedly until the result is exhausted.
 
 The result must be destroyed with `duckdb_destroy_data_chunk`.
@@ -804,6 +821,8 @@ Use `duckdb_result_chunk_count` to figure out how many chunks there are in the r
 DUCKDB_API duckdb_data_chunk duckdb_result_get_chunk(duckdb_result result, idx_t chunk_index);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Checks if the type of the internal result is StreamQueryResult.
 
 * result: The result object to check.
@@ -812,12 +831,15 @@ Checks if the type of the internal result is StreamQueryResult.
 DUCKDB_API bool duckdb_result_is_streaming(duckdb_result result);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Returns the number of data chunks present in the result.
 
 * result: The result object
 * returns: Number of data chunks present in the result.
 */
 DUCKDB_API idx_t duckdb_result_chunk_count(duckdb_result result);
+#endif
 
 /*!
 Returns the return_type of the given result, or DUCKDB_RETURN_TYPE_INVALID on error
@@ -827,6 +849,7 @@ Returns the return_type of the given result, or DUCKDB_RETURN_TYPE_INVALID on er
  */
 DUCKDB_API duckdb_result_type duckdb_result_return_type(duckdb_result result);
 
+#ifndef DUCKDB_API_NO_DEPRECATED
 //===--------------------------------------------------------------------===//
 // Safe fetch functions
 //===--------------------------------------------------------------------===//
@@ -837,91 +860,127 @@ DUCKDB_API duckdb_result_type duckdb_result_return_type(duckdb_result result);
 // For fast access of values prefer using `duckdb_result_get_chunk`
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The boolean value at the specified location, or false if the value cannot be converted.
  */
 DUCKDB_API bool duckdb_value_boolean(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The int8_t value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API int8_t duckdb_value_int8(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The int16_t value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API int16_t duckdb_value_int16(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The int32_t value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API int32_t duckdb_value_int32(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The int64_t value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API int64_t duckdb_value_int64(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The duckdb_hugeint value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API duckdb_hugeint duckdb_value_hugeint(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The duckdb_uhugeint value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API duckdb_uhugeint duckdb_value_uhugeint(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The duckdb_decimal value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API duckdb_decimal duckdb_value_decimal(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The uint8_t value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API uint8_t duckdb_value_uint8(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The uint16_t value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API uint16_t duckdb_value_uint16(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The uint32_t value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API uint32_t duckdb_value_uint32(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The uint64_t value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API uint64_t duckdb_value_uint64(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The float value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API float duckdb_value_float(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The double value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API double duckdb_value_double(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The duckdb_date value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API duckdb_date duckdb_value_date(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The duckdb_time value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API duckdb_time duckdb_value_time(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The duckdb_timestamp value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API duckdb_timestamp duckdb_value_timestamp(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The duckdb_interval value at the specified location, or 0 if the value cannot be converted.
  */
 DUCKDB_API duckdb_interval duckdb_value_interval(duckdb_result *result, idx_t col, idx_t row);
@@ -934,6 +993,8 @@ converted. The result must be freed with `duckdb_free`.
 DUCKDB_API char *duckdb_value_varchar(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: The string value at the specified location. Attempts to cast the result value to string.
  * No support for nested types, and for other complex types.
  * The resulting field "string.data" must be freed with `duckdb_free.`
@@ -961,15 +1022,20 @@ The result must NOT be freed.
 DUCKDB_API duckdb_string duckdb_value_string_internal(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 * returns: The duckdb_blob value at the specified location. Returns a blob with blob.data set to nullptr if the
 value cannot be converted. The resulting field "blob.data" must be freed with `duckdb_free.`
 */
 DUCKDB_API duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
  * returns: Returns true if the value at the specified index is NULL, and false otherwise.
  */
 DUCKDB_API bool duckdb_value_is_null(duckdb_result *result, idx_t col, idx_t row);
+#endif
 
 //===--------------------------------------------------------------------===//
 // Helpers
@@ -1405,7 +1471,10 @@ Note that the result must be freed with `duckdb_destroy_result`.
 DUCKDB_API duckdb_state duckdb_execute_prepared(duckdb_prepared_statement prepared_statement,
                                                 duckdb_result *out_result);
 
+#ifndef DUCKDB_API_NO_DEPRECATED
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Executes the prepared statement with the given bound parameters, and returns an optionally-streaming query result.
 To determine if the resulting query was in fact streamed, use `duckdb_result_is_streaming`
 
@@ -1420,6 +1489,7 @@ Note that the result must be freed with `duckdb_destroy_result`.
 */
 DUCKDB_API duckdb_state duckdb_execute_prepared_streaming(duckdb_prepared_statement prepared_statement,
                                                           duckdb_result *out_result);
+#endif
 
 //===--------------------------------------------------------------------===//
 // Extract Statements
@@ -1492,8 +1562,10 @@ Note that after calling `duckdb_pending_prepared`, the pending result should alw
 */
 DUCKDB_API duckdb_state duckdb_pending_prepared(duckdb_prepared_statement prepared_statement,
                                                 duckdb_pending_result *out_result);
-
+#ifndef DUCKDB_API_NO_DEPRECATED
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Executes the prepared statement with the given bound parameters, and returns a pending result.
 This pending result will create a streaming duckdb_result when executed.
 The pending result represents an intermediate structure for a query that is not yet fully executed.
@@ -1507,6 +1579,7 @@ Note that after calling `duckdb_pending_prepared_streaming`, the pending result 
 */
 DUCKDB_API duckdb_state duckdb_pending_prepared_streaming(duckdb_prepared_statement prepared_statement,
                                                           duckdb_pending_result *out_result);
+#endif
 
 /*!
 Closes the pending result and de-allocates all memory allocated for the result.
@@ -2170,6 +2243,7 @@ Equivalent to `duckdb_validity_set_row_validity` with valid set to true.
 */
 DUCKDB_API void duckdb_validity_set_row_valid(uint64_t *validity, idx_t row);
 
+#ifndef DUCKDB_NO_EXTENSION_FUNCTIONS
 //===--------------------------------------------------------------------===//
 // Table Functions
 //===--------------------------------------------------------------------===//
@@ -2516,6 +2590,7 @@ Report that an error has occurred while executing the replacement scan.
 * error: The error message
 */
 DUCKDB_API void duckdb_replacement_scan_set_error(duckdb_replacement_scan_info info, const char *error);
+#endif
 
 //===--------------------------------------------------------------------===//
 // Appender
@@ -2743,11 +2818,14 @@ If the append is successful, DuckDBSuccess is returned.
 */
 DUCKDB_API duckdb_state duckdb_append_data_chunk(duckdb_appender appender, duckdb_data_chunk chunk);
 
+#ifndef DUCKDB_API_NO_DEPRECATED
 //===--------------------------------------------------------------------===//
 // Arrow Interface
 //===--------------------------------------------------------------------===//
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Executes a SQL query within a connection and stores the full (materialized) result in an arrow structure.
 If the query fails to execute, DuckDBError is returned and the error message can be retrieved by calling
 `duckdb_query_arrow_error`.
@@ -2763,6 +2841,8 @@ query fails, otherwise the error stored within the result will not be freed corr
 DUCKDB_API duckdb_state duckdb_query_arrow(duckdb_connection connection, const char *query, duckdb_arrow *out_result);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Fetch the internal arrow schema from the arrow result. Remember to call release on the respective
 ArrowSchema object.
 
@@ -2773,6 +2853,8 @@ ArrowSchema object.
 DUCKDB_API duckdb_state duckdb_query_arrow_schema(duckdb_arrow result, duckdb_arrow_schema *out_schema);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Fetch the internal arrow schema from the prepared statement. Remember to call release on the respective
 ArrowSchema object.
 
@@ -2783,6 +2865,8 @@ ArrowSchema object.
 DUCKDB_API duckdb_state duckdb_prepared_arrow_schema(duckdb_prepared_statement prepared,
                                                      duckdb_arrow_schema *out_schema);
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Convert a data chunk into an arrow struct array. Remember to call release on the respective
 ArrowArray object.
 
@@ -2793,6 +2877,8 @@ ArrowArray object.
 DUCKDB_API void duckdb_result_arrow_array(duckdb_result result, duckdb_data_chunk chunk, duckdb_arrow_array *out_array);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Fetch an internal arrow struct array from the arrow result. Remember to call release on the respective
 ArrowArray object.
 
@@ -2806,6 +2892,8 @@ So consume the out_array before calling this function again.
 DUCKDB_API duckdb_state duckdb_query_arrow_array(duckdb_arrow result, duckdb_arrow_array *out_array);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Returns the number of columns present in the arrow result object.
 
 * result: The result object.
@@ -2814,6 +2902,8 @@ Returns the number of columns present in the arrow result object.
 DUCKDB_API idx_t duckdb_arrow_column_count(duckdb_arrow result);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Returns the number of rows present in the arrow result object.
 
 * result: The result object.
@@ -2822,6 +2912,8 @@ Returns the number of rows present in the arrow result object.
 DUCKDB_API idx_t duckdb_arrow_row_count(duckdb_arrow result);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Returns the number of rows changed by the query stored in the arrow result. This is relevant only for
 INSERT/UPDATE/DELETE queries. For other queries the rows_changed will be 0.
 
@@ -2831,7 +2923,9 @@ INSERT/UPDATE/DELETE queries. For other queries the rows_changed will be 0.
 DUCKDB_API idx_t duckdb_arrow_rows_changed(duckdb_arrow result);
 
 /*!
-Returns the error message contained within the result. The error is only set if `duckdb_query_arrow` returns
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
+ Returns the error message contained within the result. The error is only set if `duckdb_query_arrow` returns
 `DuckDBError`.
 
 The error message should not be freed. It will be de-allocated when `duckdb_destroy_arrow` is called.
@@ -2842,6 +2936,8 @@ The error message should not be freed. It will be de-allocated when `duckdb_dest
 DUCKDB_API const char *duckdb_query_arrow_error(duckdb_arrow result);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Closes the result and de-allocates all memory allocated for the arrow result.
 
 * result: The result to destroy.
@@ -2849,6 +2945,8 @@ Closes the result and de-allocates all memory allocated for the arrow result.
 DUCKDB_API void duckdb_destroy_arrow(duckdb_arrow *result);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Releases the arrow array stream and de-allocates its memory.
 
 * stream: The arrow array stream to destroy.
@@ -2856,6 +2954,8 @@ Releases the arrow array stream and de-allocates its memory.
 DUCKDB_API void duckdb_destroy_arrow_stream(duckdb_arrow_stream *stream_p);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Executes the prepared statement with the given bound parameters, and returns an arrow query result.
 Note that after running `duckdb_execute_prepared_arrow`, `duckdb_destroy_arrow` must be called on the result object.
 
@@ -2867,6 +2967,8 @@ DUCKDB_API duckdb_state duckdb_execute_prepared_arrow(duckdb_prepared_statement 
                                                       duckdb_arrow *out_result);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Scans the Arrow stream and creates a view with the given name.
 
 * connection: The connection on which to execute the scan.
@@ -2878,6 +2980,8 @@ DUCKDB_API duckdb_state duckdb_arrow_scan(duckdb_connection connection, const ch
                                           duckdb_arrow_stream arrow);
 
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Scans the Arrow array and creates a view with the given name.
 Note that after running `duckdb_arrow_array_scan`, `duckdb_destroy_arrow_stream` must be called on the out stream.
 
@@ -2891,7 +2995,9 @@ Note that after running `duckdb_arrow_array_scan`, `duckdb_destroy_arrow_stream`
 DUCKDB_API duckdb_state duckdb_arrow_array_scan(duckdb_connection connection, const char *table_name,
                                                 duckdb_arrow_schema arrow_schema, duckdb_arrow_array arrow_array,
                                                 duckdb_arrow_stream *out_stream);
+#endif
 
+#ifndef DUCKDB_NO_EXTENSION_FUNCTIONS
 //===--------------------------------------------------------------------===//
 // Threading Information
 //===--------------------------------------------------------------------===//
@@ -2972,12 +3078,15 @@ Returns true if the execution of the current query is finished.
 * con: The connection on which to check
 */
 DUCKDB_API bool duckdb_execution_is_finished(duckdb_connection con);
+#endif
 
 //===--------------------------------------------------------------------===//
 // Streaming Result Interface
 //===--------------------------------------------------------------------===//
-
+#ifndef DUCKDB_API_NO_DEPRECATED
 /*!
+**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.
+
 Fetches a data chunk from the (streaming) duckdb_result. This function should be called repeatedly until the result is
 exhausted.
 
@@ -2994,6 +3103,19 @@ It is not known beforehand how many chunks will be returned by this result.
 * returns: The resulting data chunk. Returns `NULL` if the result has an error.
 */
 DUCKDB_API duckdb_data_chunk duckdb_stream_fetch_chunk(duckdb_result result);
+#endif
+
+/*!
+Fetches a data chunk from a duckdb_result. This function should be called repeatedly until the result is exhausted.
+
+The result must be destroyed with `duckdb_destroy_data_chunk`.
+
+It is not known beforehand how many chunks will be returned by this result.
+
+* result: The result object to fetch the data chunk from.
+* returns: The resulting data chunk. Returns `NULL` if the result has an error.
+*/
+DUCKDB_API duckdb_data_chunk duckdb_fetch_chunk(duckdb_result result);
 
 #ifdef __cplusplus
 }

--- a/src/include/duckdb/common/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file_reader.hpp
@@ -52,6 +52,7 @@ struct MultiFileReaderBindData {
 struct MultiFileReaderGlobalState {
 	MultiFileReaderGlobalState(vector<LogicalType> extra_columns_p, optional_ptr<const MultiFileList> file_list_p)
 	    : extra_columns(std::move(extra_columns_p)), file_list(file_list_p) {};
+	virtual ~MultiFileReaderGlobalState();
 
 	//! extra columns that will be produced during scanning
 	const vector<LogicalType> extra_columns;

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -54,6 +54,11 @@ public:
 	DatabaseInstance &GetDatabase() {
 		return db;
 	}
+
+	optional_ptr<StorageExtension> GetStorageExtension() {
+		return storage_extension;
+	}
+
 	const string &GetName() const {
 		return name;
 	}
@@ -74,6 +79,7 @@ private:
 	unique_ptr<TransactionManager> transaction_manager;
 	AttachedDatabaseType type;
 	optional_ptr<Catalog> parent_catalog;
+	optional_ptr<StorageExtension> storage_extension;
 	bool is_initial_database = false;
 	bool is_closed = false;
 };

--- a/src/include/duckdb/storage/storage_extension.hpp
+++ b/src/include/duckdb/storage/storage_extension.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/access_mode.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
+#include "duckdb/storage/storage_manager.hpp"
 
 namespace duckdb {
 class AttachedDatabase;
@@ -39,6 +40,12 @@ public:
 	shared_ptr<StorageExtensionInfo> storage_info;
 
 	virtual ~StorageExtension() {
+	}
+
+	virtual void OnCheckpointStart(AttachedDatabase &db, CheckpointOptions checkpoint_options) {
+	}
+
+	virtual void OnCheckpointEnd(AttachedDatabase &db, CheckpointOptions checkpoint_options) {
 	}
 };
 

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -41,14 +41,15 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, str
 	internal = true;
 }
 
-AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, StorageExtension &storage_extension,
+AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, StorageExtension &storage_extension_p,
                                    ClientContext &context, string name_p, const AttachInfo &info,
                                    AccessMode access_mode)
-    : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), parent_catalog(&catalog_p) {
+    : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), parent_catalog(&catalog_p),
+      storage_extension(&storage_extension_p) {
 	type = access_mode == AccessMode::READ_ONLY ? AttachedDatabaseType::READ_ONLY_DATABASE
 	                                            : AttachedDatabaseType::READ_WRITE_DATABASE;
-	catalog =
-	    storage_extension.attach(storage_extension.storage_info.get(), context, *this, name, *info.Copy(), access_mode);
+	catalog = storage_extension->attach(storage_extension->storage_info.get(), context, *this, name, *info.Copy(),
+	                                    access_mode);
 	if (!catalog) {
 		throw InternalException("AttachedDatabase - attach function did not return a catalog");
 	}
@@ -57,7 +58,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 		storage = make_uniq<SingleFileStorageManager>(*this, info.path, access_mode == AccessMode::READ_ONLY);
 	}
 	transaction_manager =
-	    storage_extension.create_transaction_manager(storage_extension.storage_info.get(), *this, *catalog);
+	    storage_extension->create_transaction_manager(storage_extension->storage_info.get(), *this, *catalog);
 	if (!transaction_manager) {
 		throw InternalException(
 		    "AttachedDatabase - create_transaction_manager function did not return a transaction manager");

--- a/src/main/capi/stream-c.cpp
+++ b/src/main/capi/stream-c.cpp
@@ -7,19 +7,28 @@ duckdb_data_chunk duckdb_stream_fetch_chunk(duckdb_result result) {
 		return nullptr;
 	}
 	auto &result_data = *((duckdb::DuckDBResultData *)result.internal_data);
-	if (result_data.result_set_type == duckdb::CAPIResultSetType::CAPI_RESULT_TYPE_DEPRECATED) {
-		return nullptr;
-	}
 	if (result_data.result->type != duckdb::QueryResultType::STREAM_RESULT) {
 		// We can only fetch from a StreamQueryResult
 		return nullptr;
 	}
-	result_data.result_set_type = duckdb::CAPIResultSetType::CAPI_RESULT_TYPE_STREAMING;
-	auto &streaming = (duckdb::StreamQueryResult &)*result_data.result;
-	if (!streaming.IsOpen()) {
+	return duckdb_fetch_chunk(result);
+}
+
+duckdb_data_chunk duckdb_fetch_chunk(duckdb_result result) {
+	if (!result.internal_data) {
 		return nullptr;
 	}
+	auto &result_data = *((duckdb::DuckDBResultData *)result.internal_data);
+	if (result_data.result_set_type == duckdb::CAPIResultSetType::CAPI_RESULT_TYPE_DEPRECATED) {
+		return nullptr;
+	}
+	result_data.result_set_type = duckdb::CAPIResultSetType::CAPI_RESULT_TYPE_STREAMING;
+	auto &result_instance = (duckdb::QueryResult &)*result_data.result;
 	// FetchRaw ? Do we care about flattening them?
-	auto chunk = streaming.Fetch();
-	return reinterpret_cast<duckdb_data_chunk>(chunk.release());
+	try {
+		auto chunk = result_instance.Fetch();
+		return reinterpret_cast<duckdb_data_chunk>(chunk.release());
+	} catch (std::exception &e) {
+		return nullptr;
+	}
 }

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -122,6 +122,8 @@ static const DefaultExtension internal_extensions[] = {
     {"arrow", "A zero-copy data integration between Apache Arrow and DuckDB", false},
     {"azure", "Adds a filesystem abstraction for Azure blob storage to DuckDB", false},
     {"iceberg", "Adds support for Apache Iceberg", false},
+    {"vss", "Adds indexing support to accelerate Vector Similarity Search", false},
+    {"delta", "Adds support for Delta Lake", false},
     {nullptr, nullptr, false}};
 
 idx_t ExtensionHelper::DefaultExtensionCount() {

--- a/test/api/capi/CMakeLists.txt
+++ b/test/api/capi/CMakeLists.txt
@@ -14,7 +14,8 @@ add_library_unity(
   test_capi_complex_types.cpp
   test_capi_to_decimal.cpp
   test_capi_replacement_scan.cpp
-  test_capi_streaming.cpp)
+  test_capi_streaming.cpp
+  test_without_disabled_functions.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_sql_capi>
     PARENT_SCOPE)

--- a/test/api/capi/test_without_disabled_functions.cpp
+++ b/test/api/capi/test_without_disabled_functions.cpp
@@ -1,0 +1,41 @@
+#include "catch.hpp"
+#define DUCKDB_API_NO_DEPRECATED
+#define DUCKDB_NO_EXTENSION_FUNCTIONS
+
+#include "duckdb.h"
+
+using namespace std;
+
+// we only use functions that are cool to use in the 1.0 API
+TEST_CASE("Test without deprecated or future moved functions", "[capi]") {
+	duckdb_database database;
+	duckdb_connection connection;
+	duckdb_prepared_statement statement;
+	duckdb_result result;
+
+	REQUIRE(duckdb_open(NULL, &database) == DuckDBSuccess);
+	REQUIRE(duckdb_connect(database, &connection) == DuckDBSuccess);
+	REQUIRE(duckdb_prepare(connection, "SELECT ?::INTEGER AS a", &statement) == DuckDBSuccess);
+	REQUIRE(duckdb_bind_int32(statement, 1, 42) == DuckDBSuccess);
+	REQUIRE(duckdb_execute_prepared(statement, &result) == DuckDBSuccess);
+
+	REQUIRE(duckdb_column_count(&result) == 1);
+	REQUIRE(string(duckdb_column_name(&result, 0)) == "a");
+	REQUIRE(duckdb_column_type(&result, 0) == DUCKDB_TYPE_INTEGER);
+
+	auto chunk = duckdb_fetch_chunk(result);
+	REQUIRE(chunk);
+	auto vector = duckdb_data_chunk_get_vector(chunk, 0);
+	REQUIRE(vector);
+	auto validity = duckdb_vector_get_validity(vector);
+	REQUIRE(duckdb_validity_row_is_valid(validity, 0));
+	auto data = (int *)duckdb_vector_get_data(vector);
+	REQUIRE(data);
+	REQUIRE(data[0] == 42);
+
+	duckdb_destroy_data_chunk(&chunk);
+	duckdb_destroy_result(&result);
+	duckdb_destroy_prepare(&statement);
+	duckdb_disconnect(&connection);
+	duckdb_close(&database);
+}

--- a/test/extension/duckdb_extensions.test
+++ b/test/extension/duckdb_extensions.test
@@ -1,0 +1,47 @@
+# name: test/extension/duckdb_extensions.test
+# description: Tests for the duckdb_extensions() table function
+# group: [extension]
+
+# This test assumes icu and json to be available in the LOCAL_EXTENSION_REPO and NOT linked into duckdb statically
+# -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
+require-env LOCAL_EXTENSION_REPO
+
+require no_extension_autoloading
+
+statement ok
+PRAGMA enable_verification
+
+# Set the repository to the correct one
+statement ok
+set custom_extension_repository='${LOCAL_EXTENSION_REPO}'
+
+# Ensure we have a clean extension directory without any preinstalled extensions
+statement ok
+set extension_directory='__TEST_DIR__/duckdb_extensions'
+
+require json
+
+# json is statically linked
+query II
+SELECT extension_name, install_mode from duckdb_extensions() where extension_name='json'
+----
+json	STATICALLY_LINKED
+
+# now we install json (happens when users install extensions that are also statically loaded)
+statement ok
+install json
+
+# json still shown as statically linked
+query II
+SELECT extension_name, install_mode from duckdb_extensions() where extension_name='json'
+----
+json	STATICALLY_LINKED
+
+statement ok
+load json
+
+# json still shown as statically linked
+query II
+SELECT extension_name, install_mode from duckdb_extensions() where extension_name='json'
+----
+json	STATICALLY_LINKED

--- a/test/extension/load_extension.test
+++ b/test/extension/load_extension.test
@@ -12,14 +12,17 @@ PRAGMA enable_verification
 statement error
 LOAD 'asdf';
 ----
+<REGEX>:.*IO Error: Extension.*not found.*
 
 statement error
 LOAD 'Makefile';
 ----
+<REGEX>:.*IO Error: Extension.*not found.*
 
 statement error
 LOAD NULL;
 ----
+<REGEX>:.*Parser Error: syntax error.*
 
 statement ok
 LOAD '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
@@ -50,6 +53,7 @@ QUACK
 statement error
 QUAC
 ----
+<REGEX>:.*Parser Error:.*
 
 statement error
 QUACK NOT QUACK

--- a/test/extension/test_alias_point.test
+++ b/test/extension/test_alias_point.test
@@ -40,10 +40,12 @@ SELECT sub_point(({'x': 2, 'y': 3})::POINT, ({'x': 3, 'y': 4})::POINT)
 statement error
 SELECT add_point(pt, pt) from points;
 ----
+<REGEX>:.*Binder Error:.*No function matches the given name and argument type.*
 
 statement error
 SELECT sub_point(pt, pt) from points;
 ----
+<REGEX>:.*Binder Error:.*No function matches the given name and argument type.*
 
 query I
 SELECT add_point(point, point) from points;

--- a/test/sql/aggregate/aggregates/test_approx_quantile.test
+++ b/test/sql/aggregate/aggregates/test_approx_quantile.test
@@ -141,6 +141,19 @@ FROM (
 ----
 [true, true, true]
 
+# Array lists
+query I
+SELECT approx_quantile(col, [0.5, 0.4, 0.1]) AS percentile 
+FROM VALUES (0), (1), (2), (10) AS tab(col);
+----
+[2, 1, 0]
+
+query I
+SELECT approx_quantile(col, ARRAY_VALUE(0.5, 0.4, 0.1)) AS percentile 
+FROM VALUES (0), (1), (2), (10) AS tab(col);
+----
+[2, 1, 0]
+
 # Errors
 statement error
 SELECT approx_quantile(r, -0.1) FROM quantile

--- a/test/sql/aggregate/aggregates/test_quantile_disc_list.test
+++ b/test/sql/aggregate/aggregates/test_quantile_disc_list.test
@@ -165,6 +165,13 @@ SELECT quantile_disc(42::UTINYINT, 0.5);
 ----
 42
 
+# Array arguments
+query I
+SELECT quantile_disc(col, ARRAY_VALUE(0.5, 0.4, 0.1)) AS percentile 
+FROM VALUES (0), (1), (2), (10) AS tab(col);
+----
+[1, 1, 0]
+
 # Invalid use
 statement error
 SELECT quantile_disc(r, [-0.1, 0.5, 0.9]) FROM quantiles

--- a/test/sql/copy_database/copy_database_index.test
+++ b/test/sql/copy_database/copy_database_index.test
@@ -1,0 +1,27 @@
+# name: test/sql/copy_database/copy_database_index.test
+# description: Test COPY DATABASE with indexes
+# group: [copy_database]
+
+require noforcestorage
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH DATABASE ':memory:' AS db1;
+
+statement ok
+USE db1
+
+statement ok
+CREATE TABLE test(a INTEGER, b INTEGER, c VARCHAR(10));
+
+statement ok
+CREATE INDEX i_index ON test(a)
+
+statement ok
+INSERT INTO test VALUES (42, 88, 'hello');
+
+statement error
+COPY FROM DATABASE db1 TO memory
+----

--- a/test/sql/extensions/description_is_valid.test
+++ b/test/sql/extensions/description_is_valid.test
@@ -1,0 +1,19 @@
+# name: test/sql/extensions/description_is_valid.test
+# description: Test version metadata on load
+# group: [extensions]
+
+require inet
+
+statement ok
+SET autoinstall_known_extensions=true;
+
+statement ok
+SET autoload_known_extensions=true;
+
+statement ok
+LOAD inet;
+
+query I
+SELECT description FROM duckdb_extensions() WHERE extension_name == 'inet';
+----
+Adds support for IP-related data types and functions

--- a/test/sql/storage/wal/wal_lazy_creation.test
+++ b/test/sql/storage/wal/wal_lazy_creation.test
@@ -1,28 +1,38 @@
 # name: test/sql/storage/wal/wal_lazy_creation.test
-# description: Verify the WAL is lazily created when attaching
+# description: Verify the WAL is lazily created when attaching.
 # group: [wal]
+
+# If we enable alternative verification, then we disable checkpointing on shutdown.
+# Thus, we'll keep the WAL alive when detaching the database.
+require noalternativeverify
 
 require noforcestorage
 
 require skip_reload
 
 statement ok
-ATTACH '__TEST_DIR__/attach_no_wal.db'
+ATTACH '__TEST_DIR__/attach_no_wal.db';
 
 statement ok
-CREATE TABLE attach_no_wal.integers(i INTEGER)
+CREATE TABLE attach_no_wal.integers(i INTEGER);
 
 statement ok
 INSERT INTO attach_no_wal.integers FROM range(10000);
 
 statement ok
-DETACH attach_no_wal
+DETACH attach_no_wal;
 
 statement ok
-ATTACH '__TEST_DIR__/attach_no_wal.db'
+ATTACH '__TEST_DIR__/attach_no_wal.db';
 
-# verify we don't have a WAL after attaching
+# Verify that we don't have a WAL after attaching.
 query I
-SELECT COUNT(*) FROM glob('__TEST_DIR__/attach_no_wal.db.wal')
+SELECT COUNT(*) FROM glob('__TEST_DIR__/attach_no_wal.db.wal');
 ----
 0
+
+# Verify that we checkpointed the WAL.
+query I
+SELECT COUNT(*) FROM attach_no_wal.integers;
+----
+10000

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -547,7 +547,7 @@ bool TestResultHelper::CompareValues(SQLLogicTestLogger &logger, MaterializedQue
 	}
 	auto resString = result.ToString();
 	bool regex_matches = RE2::FullMatch(result.ToString(), re);
-	if (regex_matches == want_match) {
+	if (regex_matches && regex_matches == want_match) {
 		return true;
 	}
 	return false;

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -296,6 +296,8 @@ bool TestResultHelper::CheckStatementResult(const Statement &statement, ExecuteC
 				auto resString = result.ToString();
 				bool regex_matches = RE2::FullMatch(result.ToString(), re);
 				if (regex_matches == want_match) {
+					string success_log = StringUtil::Format("CheckStatementResult: %s:%d", statement.file_name, statement.query_line);
+					REQUIRE(success_log.c_str());
 					return true;
 				}
 

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -533,7 +533,7 @@ bool TestResultHelper::CompareValues(SQLLogicTestLogger &logger, MaterializedQue
 
 bool TestResultHelper::CompareValues(SQLLogicTestLogger &logger, MaterializedQueryResult &result, string rvalue_str) {
 	bool want_match = StringUtil::StartsWith(rvalue_str, "<REGEX>:");
-	string regex_str = StringUtil::Replace(StringUtil::Replace(rvalue_str, "<REGEX>:", ""), "!<REGEX>:", "");
+	string regex_str = StringUtil::Replace(rvalue_str, "<REGEX>:", "");
 	RE2::Options options;
 	options.set_dot_nl(true);
 	RE2 re(regex_str, options);

--- a/test/sqlite/result_helper.hpp
+++ b/test/sqlite/result_helper.hpp
@@ -27,13 +27,13 @@ public:
 	                      duckdb::unique_ptr<MaterializedQueryResult> owned_result);
 	bool CheckStatementResult(const Statement &statement, ExecuteContext &context,
 	                          duckdb::unique_ptr<MaterializedQueryResult> owned_result);
-
 	string SQLLogicTestConvertValue(Value value, LogicalType sql_type, bool original_sqlite_test);
 	void DuckDBConvertResult(MaterializedQueryResult &result, bool original_sqlite_test, vector<string> &out_result);
 
 	static bool ResultIsHash(const string &result);
 	static bool ResultIsFile(string result);
 
+	bool CompareValues(SQLLogicTestLogger &logger, MaterializedQueryResult &result, string rvalue_str);
 	bool CompareValues(SQLLogicTestLogger &logger, MaterializedQueryResult &result, string lvalue_str,
 	                   string rvalue_str, idx_t current_row, idx_t current_column, vector<string> &values,
 	                   idx_t expected_column_count, bool row_wise, vector<string> &result_values);


### PR DESCRIPTION
New variation of CompareValues() to match expected error messages in a format of regex like this:

```
statement error
LOAD 'Makefile';
----
<REGEX>:.*IO Error: Extension.*not found.*

statement error
LOAD NULL;
----
<REGEX>:.*Parser Error: syntax error.*
```